### PR TITLE
Add warning to python readme re: supported versions

### DIFF
--- a/python-demo/README.md
+++ b/python-demo/README.md
@@ -1,5 +1,7 @@
 # Python demo
 
+> ❗ **WARNING:** Graceful shutdown using SIGTERM is currently only compatible with python 3.12. See #2
+
 This folder contains a simple python function with CloudWatch Lambda Insight enabled. CloudWatch Lambda Insight is monitoring and troubleshooting solution for serverless applicaiton. Its agent is an external extension. Any external extension will work. We use Lambda Insight extension simply because it is readily available.
 
 ```yaml


### PR DESCRIPTION
*Issue #, if available:*

See #2

*Description of changes:*

Add a warning to the python readme, that the examples in this repo are only supported by version 3.12. Many (if not _most_) users of python lambdas are not yet on 3.12. The readme as currently written is likely to cost developers much lost time.
